### PR TITLE
32 prerelease of v020 seems unstable

### DIFF
--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -448,8 +448,21 @@ public class CPHInline
 			if (!isArrangementIdentified)
 			{
 				isArrangementIdentified = identifyArrangement();
-                saveSongMetaData();
-			}
+                try
+                {
+                    saveSongMetaData();
+                }
+                catch ( ObjectDisposedException e)
+                {
+                    debug("Caught object disposed exception when trying to save meta data: " + e.Message);
+                    debug("Trying to reinitialize");
+                    Init();
+                }
+                catch (Exception e )
+                {
+                    debug("Caugt unknown exception when trying to write song meta data: " + e.Message);
+                }
+            }
             if (!currentScene.Equals(songScene))
             {
                 if (!currentResponse.MemoryReadout.SongTimer.Equals(lastSongTimer))
@@ -571,7 +584,20 @@ public class CPHInline
             {
                 if (parseLatestResponse())
                 {
-                    saveNoteDataIfNecessary();
+                    try
+                    {
+                        saveNoteDataIfNecessary();
+                    }
+                    catch (ObjectDisposedException e)
+                    {
+                        debug("Caught object disposed exception when trying to save note data: " + e.Message);
+                        debug("Trying to reinitialize");
+                        Init();
+                    }
+                    catch (Exception e)
+                    {
+                        debug("Caugt unknown exception when trying to write song meta data: " + e.Message);
+                    }
                     performSceneSwitchIfNecessary();
                     if (isReactingToSections)
                     {

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -97,7 +97,7 @@ public class CPHInline
     }
 
     //Needs to be commented out in streamer bot.
-    //private CPHmock CPH = new CPHmock();
+    private CPHmock CPH = new CPHmock();
 
 
     private string snifferIp = null!;
@@ -351,7 +351,7 @@ public class CPHInline
                     additionalNotes = (uint)(currentResponse.MemoryReadout.NoteData.TotalNotes);
                 }
                 totalNotesHitThisStream += additionalNotesHit;
-                totalNotesMissedThisStream+= additionalNotesMissed;
+                totalNotesMissedThisStream += additionalNotesMissed;
                 totalNotesThisStream += additionalNotes;
                 CPH.SetGlobalVar("totalNotesSinceLaunch", totalNotesThisStream, false);
                 CPH.SetGlobalVar("totalNotesHitSinceLaunch", totalNotesHitThisStream, false);
@@ -363,6 +363,7 @@ public class CPHInline
                 CPH.SetGlobalVar("accuracySinceLaunch", accuracyThisStream, false);            
 
                 lastNoteData = currentResponse.MemoryReadout.NoteData;
+                Console.WriteLine(string.Format("Notes this stream: {0}/{1}. Accuracy: {2}",totalNotesHitThisStream,totalNotesThisStream, accuracyThisStream));
             }
         }
     }
@@ -517,6 +518,7 @@ public class CPHInline
             {
                 isArrangementIdentified = false;
 				invalidateGlobalVariables();
+                lastNoteData = null;
                 CPH.RunAction("SongEnd");
             }
         }

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -97,7 +97,7 @@ public class CPHInline
     }
 
     //Needs to be commented out in streamer bot.
-    private CPHmock CPH = new CPHmock();
+    //private CPHmock CPH = new CPHmock();
 
 
     private string snifferIp = null!;
@@ -363,7 +363,7 @@ public class CPHInline
                 CPH.SetGlobalVar("accuracySinceLaunch", accuracyThisStream, false);            
 
                 lastNoteData = currentResponse.MemoryReadout.NoteData;
-                Console.WriteLine(string.Format("Notes this stream: {0}/{1}. Accuracy: {2}",totalNotesHitThisStream,totalNotesThisStream, accuracyThisStream));
+                //Console.WriteLine(string.Format("Notes this stream: {0}/{1}. Accuracy: {2}",totalNotesHitThisStream,totalNotesThisStream, accuracyThisStream));
             }
         }
     }

--- a/SB_SceneSwitcher/Program.cs
+++ b/SB_SceneSwitcher/Program.cs
@@ -96,6 +96,10 @@ public class CPHInline
         ,AlwaysOn
     }
 
+    //Needs to be commented out in streamer bot.
+    //private CPHmock CPH = new CPHmock();
+
+
     private string snifferIp = null!;
     private string snifferPort = null!;
 
@@ -119,8 +123,6 @@ public class CPHInline
     private UInt32 totalNotesMissedThisStream;
     private double accuracyThisStream;
 
-
-
     private string menuScene = null!;
     private string songScene = null!;
     private string songPausedScene = null!;
@@ -137,14 +139,14 @@ public class CPHInline
     private bool isSwitchingScenes = true;
     private bool isReactingToSections =true;
 	private bool isArrangementIdentified = false;
-    //Needs to be commented out in streamer bot.
-    //private CPHmock CPH = new CPHmock();
+
     
     void debug(string str)
     {
         if (doLogToChat) CPH.SendMessage(str);
         CPH.LogDebug(str);
     }
+
     private GameStage evalGameStage(string stage)
     {
         GameStage currentStage = GameStage.Menu;
@@ -166,7 +168,6 @@ public class CPHInline
     }
     public void Init()
     {
-
         //Init happens before arguments are passed, therefore temporary globals are used.
         snifferIp = CPH.GetGlobalVar<string>("snifferIP").Replace('"',' ').Trim();
         snifferPort = "9938";
@@ -237,6 +238,12 @@ public class CPHInline
         {
             debug("Error in response");
             debug(string.Format("Caught exception trying to get response from sniffer: {0}", e.Message));
+            success = false;
+        }
+        catch (ObjectDisposedException e)
+        {
+            debug("HttpClient was disposed. Reinitialising.");
+            Init();
             success = false;
         }
         if (!success) debug("Failed fetching response");


### PR DESCRIPTION
It seems that under some circumstances ObjectDisposed exceptions would be caused by using SetGlobalVar, as LiteDB.LiteQueryable is disposed.
Added some exception handling, trying to fix this by enforced reinitialization.
Fixed a bug leadung to note data not accumulating correctly